### PR TITLE
Sorting the Deadline table and make some changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,22 @@
 ### Description
 A repo for Human Resources Analytics by using data mining
 
+### Dates of Meetings and Other Tasks
+| Tasks | Dates | Handin Links | Tasks Status |
+| :-----: | :-----: | :--------------: | :-------------: |
+| Review of Brief | 15-Feb-2018 00:00 | [First Brief Handin](http://handin.ecs.soton.ac.uk/handin/1718/COMP6237/1/) | Open |
+| Basic Algorithm Talk | 19-Feb-2018 12:00 | Talk Through After Class | Open |
+
 ### Deadlines of The [Group Coursework](http://comp6237.ecs.soton.ac.uk/cw/coursework1.html)
 | Tasks | Dates | Handin Links | Tasks Status |
 | :-----: | :-----: | :--------------: | :-------------: |
-| Build Algorithm | 6-Feb-2018 14:00 | Talk Through After Class | Open |
 | Project Brief | 16-Feb-2018 16:00 | [Brief Handin](http://handin.ecs.soton.ac.uk/handin/1718/COMP6237/1/) | Open |
 | Conference Paper | 16-May-2018 16:00 | [Final Paper Handin](http://handin.ecs.soton.ac.uk/handin/1718/COMP6237/2/) | Open |
+
+### Overdue Deadlines
+| Tasks | Dates | Handin Links | Tasks Status |
+| :-----: | :-----: | :--------------: | :-------------: |
+| Build Algorithm | Delayed to 14-Feb-2018 11:45 | Talk Through After Class | Closed |
 
 ### Work Flow
 Follow Github Flow


### PR DESCRIPTION
Adding two tables for meeting dates and overdue deadlines instead of one which make it clearer and explecit to the actural coursework deadline.